### PR TITLE
Fix support for RHEL / CentOS nodes

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -9,14 +9,19 @@ class mosh {
     }
   
     'redhat': {
-       class { 'epel': }
-       # to get/enable EPEL repo
-       # puppet module install stahnma-epel / zerlgi-epel
-       package { $package:
-         ensure => present,
-         require => Class['epel'],
-        }
-     }
+      # It's likely that another module already includes the epel module.
+      # We only include it if it's not already defined to prevent 
+      # duplicate declarations.
+      if !defined(Class['::epel']) {
+        class { 'epel': }
+      }
+      # to get/enable EPEL repo
+      # puppet module install stahnma-epel / zerlgi-epel
+      package { $package:
+        ensure => present,
+        require => Class['epel'],
+      }
+    }
   }
 
   include mosh::iptables

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -13,7 +13,6 @@ class mosh {
        # to get/enable EPEL repo
        # puppet module install stahnma-epel / zerlgi-epel
        package { $package:
-         ensure => installed,
          ensure => present,
          require => Package['epel-release'],
         }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -1,13 +1,7 @@
 class mosh {
   $package = 'mosh'
  
-  case $::operatingsystem {
-    'ubuntu': {
-      package { $package:
-         ensure => present,
-         }
-     }
-  
+  case $::osfamily {
     'debian': {
       package { $package:
         ensure => present,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -9,12 +9,12 @@ class mosh {
     }
   
     'redhat': {
-       include epel
+       class { 'epel': }
        # to get/enable EPEL repo
        # puppet module install stahnma-epel / zerlgi-epel
        package { $package:
          ensure => present,
-         require => Package['epel-release'],
+         require => Class['epel'],
         }
      }
   }


### PR DESCRIPTION
The following PR fixes some problems with the RHEL/CentOS support:

* Case on `$osfamily` instead of `$operatingsystem` to include CentOS and not just redhat. Ubuntu is included under the debian osfamily, therefore that case is also removed.
* Fix the dependancy on `epel` to be the class instead of the `epel-release` package.
* Only include the `epel` module if it's not already defined.